### PR TITLE
Typo fix in Runner common-log handler

### DIFF
--- a/src/Ustream/Daemon/Runner.php
+++ b/src/Ustream/Daemon/Runner.php
@@ -83,7 +83,7 @@ HELP;
 				'min-sleep' => $defaultConfig->minimumSleep,
 				'memory-threshold' => $defaultConfig->memoryThreshold,
 				'log-dir' => $defaultConfig->logDir,
-				'comon-log' => $defaultConfig->customDaemonUtilLogFile,
+				'common-log' => $defaultConfig->customDaemonUtilLogFile,
 			);
 			$opts = array_merge($defaults, $opts);
 


### PR DESCRIPTION
Undefined index notice fix with the default log handler.
